### PR TITLE
Update .gitignore handling

### DIFF
--- a/src/eslint.config.js
+++ b/src/eslint.config.js
@@ -14,8 +14,14 @@ const reactPlugin = require('eslint-plugin-react')
 const reactHooksPlugin = require('eslint-plugin-react-hooks')
 const glob = require('glob')
 
-// Find all .gitignore files in the project
+// Find all .gitignore files in the project (upto 2 levels up for monorepo support)
 const gitignoreFiles = glob.sync('**/.gitignore', { cwd: process.cwd() })
+if (gitignoreFiles.length === 0) {
+  gitignoreFiles.push(...glob.sync('**/.gitignore', { cwd: path.join(process.cwd(), '..') }).map(file => path.join('..', file)))
+  if (gitignoreFiles.length === 0) {
+    gitignoreFiles.push(...glob.sync('**/.gitignore', { cwd: path.join(process.cwd(), '../..') }).map(file => path.join('..', '..', file)))
+  }
+}
 
 // Sort by directory depth (root to leaves) to match Git's override behavior
 const sortedGitignoreFiles = gitignoreFiles.sort((a, b) => {
@@ -31,11 +37,15 @@ for (const file of sortedGitignoreFiles) {
   const content = fs.readFileSync(file, 'utf8')
   const lines = content.split('\n').map(line => line.trim()).filter(line => line && !line.startsWith('#'))
   for (const line of lines) {
-    if (line.startsWith('!')) {
-      ignorePatterns.push('!' + path.join(dir, line.slice(1)))
-    } else {
-      ignorePatterns.push(path.join(dir, line))
-    }
+    let rule = path.join(dir, line).replaceAll('\\', '/')
+    if (rule.startsWith('..//')) continue // a rule intended for a parent directory
+    // rules that don't start with slash apply to all directories
+    rule = rule.replaceAll('../', '')
+    // mimic .gitignore behavior as ESlint is a bit different and doesn't recursively apply rules
+    if (!rule.startsWith('/') || !rule.startsWith('./') || !rule.startsWith('*')) rule = '**/' + rule
+    // Restore ordering of ! to front after above transformation
+    if (line.startsWith('!')) rule = '!' + rule.replaceAll('!', '')
+    ignorePatterns.push(rule)
   }
 }
 


### PR DESCRIPTION
Fix behavior inconsistency between .gitignore and ESLint v9 ignore rules (not propagating)

Also allow searching for .gitignore upto two levels up if not found in current working directory

Fix #11 